### PR TITLE
changed the target for the installation and use the tmprules to creat…

### DIFF
--- a/libfprint-2-tod1-broadcom.spec
+++ b/libfprint-2-tod1-broadcom.spec
@@ -7,33 +7,89 @@ Group:          Hardware/Mobile
 URL:            https://git.launchpad.net/~oem-solutions-engineers/libfprint-2-tod1-broadcom/+git/libfprint-2-tod1-broadcom/
 BuildRequires:  git
 BuildRequires:  pkgconfig(udev)
+BuildRequires:  selinux-policy-devel
 ExclusiveArch:  x86_64
 Supplements:    modalias(usb:v0A5Cp5842d*dc*dsc*dp*ic*isc*ip*)
 Supplements:    modalias(usb:v0A5Cp5843d*dc*dsc*dp*ic*isc*ip*)
 Supplements:    modalias(usb:v0A5Cp5844d*dc*dsc*dp*ic*isc*ip*)
 Supplements:    modalias(usb:v0A5Cp5845d*dc*dsc*dp*ic*isc*ip*)
 
+Source0:        %{url}
+Source1:        libfprint-tod-tmpfiles.conf
+Source2:        libfprint-tod-broadcom.te
+Source3:        libfprint-tod-broadcom.fc
+
 %description
 This is user space driver for Broadcom fingerprint module. Proprietary driver for the fingerprint reader on the various Dell laptops - direct from Dell's Ubuntu repo.
 
 %prep
-git clone %{url}
-cd libfprint-2-tod1-broadcom
+git clone %{url} %{name}-git-repo --depth 1
 
 %build
+# Build SELinux policy
+# Use the full path for the policy source files
+make -f /usr/share/selinux/devel/Makefile %{SOURCE2} %{SOURCE3}
+# The 'install' command needs the compiled policy. Let's make it here so it's ready.
+# We'll just build the .pp from the sources
+make -f /usr/share/selinux/devel/Makefile -C %{_sourcedir} libfprint-tod-broadcom.pp
 
 %install
-cd libfprint-2-tod1-broadcom
-install -dm 0755 %{buildroot}%{_udevrulesdir} %{buildroot}%{_libdir}/libfprint-2/tod-1 %{buildroot}%{_sharedstatedir}/fprint/fw/
-install -m 0644 lib/udev/rules.d/60-libfprint-2-device-broadcom.rules %{buildroot}%{_udevrulesdir}/60-libfprint-2-device-broadcom.rules
-install -m 0644 var/lib/fprint/fw/* %{buildroot}%{_sharedstatedir}/fprint/fw/
-install -m 0755 usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so %{buildroot}%{_libdir}/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so
+
+install -dm 0755 \
+    %{buildroot}%{_udevrulesdir} \
+    %{buildroot}%{_libdir}/libfprint-2/tod-1 \
+    %{buildroot}%{_libdir}/fprint/fw/ \
+    %{buildroot}%{_tmpfilesdir} \
+    %{buildroot}%{_datadir}/selinux/targeted/
+# License
+install -Dm0644 %{name}-git-repo/LICENCE.broadcom %{buildroot}%{_datadir}/licenses/%{name}/LICENCE.broadcom
+
+# Tmpfiles rule
+#install -m 0644 %{_sourcedir}/${name}-*/libfprint-tod-tmpfiles.conf %{buildroot}%{_tmpfilesdir}/libfprint-tod.conf
+install -m 0644 %{SOURCE1} %{buildroot}%{_tmpfilesdir}/libfprint-tod.conf
+
+# Udev rule
+install -m 0644 %{name}-git-repo/lib/udev/rules.d/60-libfprint-2-device-broadcom.rules \
+    %{buildroot}%{_udevrulesdir}/60-libfprint-2-device-broadcom.rules
+
+# Firmware
+install -m 0644 %{name}-git-repo/var/lib/fprint/fw/* %{buildroot}%{_libdir}/fprint/fw/
+
+# TOD module
+install -m 0755 %{name}-git-repo/usr/lib/x86_64-linux-gnu/libfprint-2/tod-1/*.so \
+    %{buildroot}%{_libdir}/libfprint-2/tod-1/
+
+# Install the SELinux policy module
+install -m 0644 %{_sourcedir}/libfprint-tod-broadcom.pp %{buildroot}%{_datadir}/selinux/targeted/
+install -m 0644 %{SOURCE3} %{buildroot}%{_datadir}/selinux/targeted/
+
+%post
+# Load the SELinux policy module
+semodule -i %{_datadir}/selinux/targeted/libfprint-tod-broadcom.pp
+
+# Apply the SELinux file contexts
+/usr/sbin/semanage fcontext -a -t fprintd_var_lib_t "/usr/lib64/fprint/fw(/.*)?"
+/usr/sbin/restorecon -Rv /usr/lib64/fprint/fw
+
+%postun
+# Check if the package is being completely removed
+if [ "$1" -eq 0 ]; then
+    # Unload the SELinux policy module
+    semodule -r libfprint-tod-broadcom
+
+    # Remove the SELinux file contexts
+    /usr/sbin/semanage fcontext -d "/usr/lib64/fprint/fw(/.*)?"
+    /usr/sbin/restorecon -Rv /usr/lib64/fprint/fw
+fi
 
 %files
-%attr(644, -, -) %license libfprint-2-tod1-broadcom/LICENCE.broadcom
+%license %{_datadir}/licenses/%{name}/LICENCE.broadcom
 %{_udevrulesdir}/60-libfprint-2-device-broadcom.rules
-%{_libdir}/libfprint-2/tod-1/libfprint-2-tod-1-broadcom.so
-%{_sharedstatedir}/fprint/fw/*
+%{_libdir}/libfprint-2/tod-1/*.so
+%{_libdir}/fprint/fw/*
+%{_tmpfilesdir}/libfprint-tod.conf
+%{_datadir}/selinux/targeted/libfprint-tod-broadcom.pp
+%{_datadir}/selinux/targeted/libfprint-tod-broadcom.fc
 
 %changelog
 * Sun Nov 19 2023 Chris Harvey <chris@chrisnharvey.com> - 0.0.1

--- a/libfprint-tod-broadcom.fc
+++ b/libfprint-tod-broadcom.fc
@@ -1,0 +1,5 @@
+# Label the directory where the firmware files are actually installed
+/usr/lib64/fprint/fw(/.*)?      --      gen_context(system_u:object_r:fprintd_var_lib_t,s0)
+
+# The symbolic link still needs to be labeled correctly
+/var/lib/fprint/fw              --      gen_context(system_u:object_r:fprintd_var_lib_t,s0)

--- a/libfprint-tod-broadcom.te
+++ b/libfprint-tod-broadcom.te
@@ -1,0 +1,11 @@
+policy_module(libfprint-tod-broadcom, 1.0)
+
+# Declaring the types we are working with
+type fprintd_t;
+type fprintd_var_lib_t;
+
+# Rule to allow fprintd to access files with the fprintd_var_lib_t context
+# This rule now covers both the symbolic link and the target files
+allow fprintd_t fprintd_var_lib_t:lnk_file { read };
+allow fprintd_t fprintd_var_lib_t:dir { search };
+allow fprintd_t fprintd_var_lib_t:file { read };

--- a/libfprint-tod-tmpfiles.conf
+++ b/libfprint-tod-tmpfiles.conf
@@ -1,0 +1,2 @@
+# Create /var/lib/fprint/fw as a symlink to /usr/lib/fprint/fw
+L /var/lib/fprint/fw - - - - /usr/lib64/fprint/fw


### PR DESCRIPTION
Trying to use your **COPR** package on an immutable version of Fedora that I assembled [Hyprland Atomic](https://github.com/cjuniorfox/hyprland-atomic), I was unable to get the fingerprint driver working, because of this `rpmspec` that try to write files to the `/var` directory and the **OSTree-based** installations does not allow RPM packages to write files directly to `/var`, but on `/usr` because `/var` is part of the mutable environment for the installation. So, I made a few changes to your **RPM Spec**. With that, I would like to integrate the changes into your repository and your COPR. The changes follow:

1. Instead of writing the `fw` files to `/var/lib/fprint`, they are stored on `/usr/lib64/fprint` instead.
2. Created a `tmpfiles` rule to create a **symlink** on `/var/lib/fprint` to `/usr/lib64/fprint` during system initialization.
3. Adjusted **SELinux** rules to allow `fprintd` for reading the files through a symbolic link.